### PR TITLE
Chunking ratings into size of 20

### DIFF
--- a/index.js
+++ b/index.js
@@ -473,18 +473,23 @@ async function messageManager(msg) {
 							errorHandler(err, msg)
 						}
 						else {
-							let data = recordset.recordset;
-							const newData = [];
-							for (let i = 0; i < recordset.recordset.length; i++) {
-								newData.push(recordset.recordset[i].line);
-								console.log(recordset.recordset[i].line);
+							const chunkSize = 20;
+							const chunkHolder = []
+							const numChunks = Math.floor(recordset.recordset.length / chunkSize);
+							for (let i = 0; i < numChunks; i++) {
+								chunk = recordset.recordset.slice(i*chunkSize,i+1 * chunkSize);
+								chunkHolder.push(chunk.map(x => x.line));
 							}
-
-							msg.channel.send(newData.join('\n'))
+							if (recordset.recordset.length % chunkSize !== 0){
+								chunk = recordset.recordset.slice(numChunks*chunkSize, recordset.recordset.length);
+								chunkHolder.push(chunk.map(x => x.line));
+							}
+							chunkHolder.forEach((chunk) => {
+								msg.channel.send(chunk.join('\n'))
 								.catch((err) => {
-									discordMessageErrorHandler(err, msg)
-
+									discordMessageErrorHandler(err,msg)
 								});
+							});
 						}
 					})
 				})
@@ -512,18 +517,23 @@ async function messageManager(msg) {
 							errorHandler(err, msg)
 						}
 						else {
-							let data = recordset.recordset;
-							const newData = [];
-							for (let i = 0; i < recordset.recordset.length; i++) {
-								newData.push(recordset.recordset[i].line);
-								console.log(recordset.recordset[i].line);
+							const chunkSize = 20;
+							const chunkHolder = []
+							const numChunks = Math.floor(recordset.recordset.length / chunkSize);
+							for (let i = 0; i < numChunks; i++) {
+								chunk = recordset.recordset.slice(i*chunkSize,i+1 * chunkSize);
+								chunkHolder.push(chunk.map(x => x.line));
 							}
-
-							msg.channel.send(newData.join('\n'))
+							if (recordset.recordset.length % chunkSize !== 0){
+								chunk = recordset.recordset.slice(numChunks*chunkSize, recordset.recordset.length);
+								chunkHolder.push(chunk.map(x => x.line));
+							}
+							chunkHolder.forEach((chunk) => {
+								msg.channel.send(chunk.join('\n'))
 								.catch((err) => {
-									discordMessageErrorHandler(err, msg)
-
+									discordMessageErrorHandler(err,msg)
 								});
+							});
 						}
 					})
 				})


### PR DESCRIPTION
Changing sms and msc ratings to be in chunks of 20. Size can be configurable but this should give us enough space to confidently be under the limit (we currently sit at 32 which is over the 2000 character limit). I sized it down to 20 to make it look cleaner and leave space for extremely long user names.